### PR TITLE
Locale set by user should not get reset after server restart or coldbox reinit

### DIFF
--- a/models/i18n.cfc
+++ b/models/i18n.cfc
@@ -86,13 +86,13 @@ component singleton accessors="true" {
 			);
 		}
 		// set locale setup on configuration file
-		setFWLocale( variables.defaultLocale );
+		setFWLocale( getFwLocale() );
 
 		// Verify if we have a default resource bundle, if we do, load it.
 		if ( variables.defaultResourceBundle.len() ) {
 			variables.resourceService.loadBundle(
 				rbFile  : variables.defaultResourceBundle,
-				rbLocale: variables.defaultLocale,
+				rbLocale: getFwLocale(),
 				rbAlias : "default"
 			);
 		}
@@ -101,7 +101,7 @@ component singleton accessors="true" {
 		variables.settings.resourceBundles.each( function( bundleKey, thisBundle ){
 			variables.resourceService.loadBundle(
 				rbFile  : thisBundle,
-				rbLocale: variables.defaultLocale,
+				rbLocale: getFwLocale(),
 				rbAlias : lCase( bundleKey )
 			);
 		} );


### PR DESCRIPTION
Currently each time ColdBox framework gets reinited (`?fwreinit=1`) or server restarted, user-selected locale gets reset to the default locale. 

For example, a cookie set via `setFwLocale("es_ES")` gets reset to the default "en_US" each time `?fwreinit` is called or CF server restarted. Therefore, language selection is lost and the user is forced to make language selection again. 