### PR TITLE
Typo and other fixes for getTZQuery

### DIFF
--- a/models/i18n.cfc
+++ b/models/i18n.cfc
@@ -985,11 +985,12 @@ component singleton threadsafe accessors="true" {
 		var aTZID         = getAvailableTZ();
 		var stNames       = {};
 		var qryTZ         = queryNew( "id,offset,dspName,longname,shortname,usesDST" );
-		var fReturnUnique = arguments.returUnique; // not necessary but no arguments issues in each()
+		var fReturnUnique = arguments.returnUnique; // not necessary but no arguments issues in each()
 		var tmpName       = "";
-		aTZID.each( function( timeZone ){
+		var timeZone      = "";
+		for (timeZone in aTZID) {
 			tmpName = getTZDisplayName( timeZone );
-			if ( !fReturnUnique || ( fReturnUnique && !structKeyExists( stNames, tmpname ) ) ) {
+			if ( !fReturnUnique || ( fReturnUnique && !structKeyExists( stNames, tmpName ) ) ) {
 				qryTZ.addRow( 1 );
 				qryTZ.setCell( "id", timeZone );
 				qryTZ.setCell( "offset", getRawOffset( timeZone ) );
@@ -998,13 +999,14 @@ component singleton threadsafe accessors="true" {
 				qryTZ.setCell( "shortname", getTZDisplayName( timeZone, "short" ) );
 				qryTZ.setCell( "usesDST", usesDST( timeZone ) );
 			}
-		} );
+		}
 		return qryTZ.sort( function( rowA, rowB ){
-			if ( compare( rowA.offset, rowB.offset ) == 0 ) {
-				// if locale=equal, further sort on langugage
-				return compare( rowA.dspname, rowB.dspname );
+			if (rowA.offset gt rowB.offset) {
+				return 1;
+			} else if (rowA.offset lt rowB.offset) {
+				return -1;
 			} else {
-				return compare( rowA.offset, rowB.offset );
+				return compare( rowA.dspName, rowB.dspName );
 			}
 		} );
 	}


### PR DESCRIPTION
# Description

- fix typo in returUnique
- use for loop since each() does not exist in java.lang.String[]
- modified sort to correctly sort by numeric values of offset, not string

## Type of change

- [ ] Bug Fix
- [ ] Improvement

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
