### PR TITLE
version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           forgeboxAPIKey: ${{ secrets.FORGEBOX_TOKEN }}
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: ${{ env.MODULE_ID }}
           path: .tmp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload Build Artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ env.MODULE_ID }}
           path: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -38,7 +38,7 @@ jobs:
           cmd: run-script format
 
       - name: Commit Format Changes
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Apply cfformat changes
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
           box testbox run --verbose outputFile=test-harness/tests/results/test-results outputFormats=json,antjunit
 
       - name: Publish Test Reports
-        uses: mikepenz/action-junit-report@v5.6.2
+        uses: mikepenz/action-junit-report@v6.0.1
         if: always()
         with:
           report_paths: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload Test Results to Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results-${{ matrix.cfengine }}-${{ matrix.coldboxVersion }}
           path: |
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload Debug Logs To Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Failure Debugging Info - ${{ matrix.cfengine }} - ${{ matrix.coldboxVersion }}
           path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cfengine: [ "boxlang-cfml@1", "lucee@5", "lucee@6", "adobe@2023", "adobe@2025" ]
-        coldboxVersion: [ "^7.0.0" ]
+        cfengine: [ "boxlang@1", "boxlang-cfml@1", "lucee@5", "lucee@6", "adobe@2023", "adobe@2025" ]
+        coldboxVersion: [ "^7.0.0", "^8.0.0" ]
         experimental: [ false ]
         # Experimental: ColdBox BE vs All Engines
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cfengine: [ "boxlang@1", "boxlang-cfml@1", "lucee@5", "lucee@6", "adobe@2023", "adobe@2025" ]
+        cfengine: [ "boxlang-cfml@1", "lucee@5", "lucee@6", "adobe@2023", "adobe@2025" ]
         coldboxVersion: [ "^7.0.0", "^8.0.0" ]
         experimental: [ false ]
         # Experimental: ColdBox BE vs All Engines
@@ -35,9 +35,10 @@ jobs:
           - coldboxVersion: "be"
             cfengine: "boxlang-cfml@1"
             experimental: true
-          - coldboxVersion: "be"
+         # Boxlang PRIME
+          - coldboxVersion: "^8.0.0"
             cfengine: "boxlang@1"
-            experimental: true
+            experimental: false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5

--- a/box.json
+++ b/box.json
@@ -1,7 +1,7 @@
 {
     "name":"ColdBox i18n and Localization",
     "author":"Ortus Solutions <info@ortussolutions.com>",
-    "version":"3.4.0",
+    "version":"3.5.0",
     "location":"https://downloads.ortussolutions.com/ortussolutions/coldbox-modules/cbi18n/@build.version@/cbi18n-@build.version@.zip",
     "slug":"cbi18n",
     "type":"modules",

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2025-09-18
+
 ### Added
 
 - `setFwLocale` should allow only valid values as well by @GunnarLieb
@@ -151,5 +153,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create first module version
 
-[unreleased]: https://github.com/coldbox-modules/cbi18n/compare/v3.3.0...HEAD
+[unreleased]: https://github.com/coldbox-modules/cbi18n/compare/v3.4.0...HEAD
+[3.4.0]: https://github.com/coldbox-modules/cbi18n/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/coldbox-modules/cbi18n/compare/66cb83a4dbf1c67aba786dcf59236ba73ac29f51...v3.3.0

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2025-11-10
+
+### Fixed
+
+- Fixed typo in `returnUnique` parameter name in `getTZQuery` method by @sjdaniels
+- Fixed `getTZQuery` to use for loop instead of `each()` for Java String arrays by @sjdaniels
+- Fixed `getTZQuery` sort to correctly sort by numeric offset values instead of strings by @sjdaniels
+
+### Added
+
+- BoxLang PRIME testing certification
+- Updated GitHub Actions dependencies
+
 ## [3.4.0] - 2025-09-18
 
 ### Added

--- a/models/i18n.cfc
+++ b/models/i18n.cfc
@@ -988,7 +988,7 @@ component singleton threadsafe accessors="true" {
 		var fReturnUnique = arguments.returnUnique; // not necessary but no arguments issues in each()
 		var tmpName       = "";
 		var timeZone      = "";
-		for (timeZone in aTZID) {
+		for ( timeZone in aTZID ) {
 			tmpName = getTZDisplayName( timeZone );
 			if ( !fReturnUnique || ( fReturnUnique && !structKeyExists( stNames, tmpName ) ) ) {
 				qryTZ.addRow( 1 );
@@ -1001,9 +1001,9 @@ component singleton threadsafe accessors="true" {
 			}
 		}
 		return qryTZ.sort( function( rowA, rowB ){
-			if (rowA.offset gt rowB.offset) {
+			if ( rowA.offset gt rowB.offset ) {
 				return 1;
-			} else if (rowA.offset lt rowB.offset) {
+			} else if ( rowA.offset lt rowB.offset ) {
 				return -1;
 			} else {
 				return compare( rowA.dspName, rowB.dspName );

--- a/models/i18n.cfc
+++ b/models/i18n.cfc
@@ -985,11 +985,12 @@ component singleton threadsafe accessors="true" {
 		var aTZID         = getAvailableTZ();
 		var stNames       = {};
 		var qryTZ         = queryNew( "id,offset,dspName,longname,shortname,usesDST" );
-		var fReturnUnique = arguments.returUnique; // not necessary but no arguments issues in each()
+		var fReturnUnique = arguments.returnUnique; // not necessary but no arguments issues in each()
 		var tmpName       = "";
-		aTZID.each( function( timeZone ){
+		var timeZone      = "";
+		for (timeZone in aTZID) {
 			tmpName = getTZDisplayName( timeZone );
-			if ( !fReturnUnique || ( fReturnUnique && !structKeyExists( stNames, tmpname ) ) ) {
+			if ( !fReturnUnique || ( fReturnUnique && !structKeyExists( stNames, tmpName ) ) ) {
 				qryTZ.addRow( 1 );
 				qryTZ.setCell( "id", timeZone );
 				qryTZ.setCell( "offset", getRawOffset( timeZone ) );
@@ -998,13 +999,14 @@ component singleton threadsafe accessors="true" {
 				qryTZ.setCell( "shortname", getTZDisplayName( timeZone, "short" ) );
 				qryTZ.setCell( "usesDST", usesDST( timeZone ) );
 			}
-		} );
+		}
 		return qryTZ.sort( function( rowA, rowB ){
-			if ( compare( rowA.offset, rowB.offset ) == 0 ) {
-				// if locale=equal, further sort on langugage
-				return compare( rowA.dspname, rowB.dspname );
+			if (rowA.offset gt rowB.offset) {
+				return 1;
+			} else if (rowA.offset lt rowB.offset) {
+				return -1;
 			} else {
-				return compare( rowA.offset, rowB.offset );
+				return compare( rowA.dspName, rowB.dspName );
 			}
 		} );
 	}


### PR DESCRIPTION
version bump
This pull request updates the project to version 3.5.0 and includes several bug fixes, enhancements to time zone handling, and updates to CI/CD workflows and dependencies. The most important changes are grouped below:

### Time Zone Handling Fixes (`models/i18n.cfc`)
* Fixed a typo in the `returnUnique` parameter name in the `getTZQuery` method.
* Replaced the use of `.each()` with a `for` loop for iterating over Java String arrays in `getTZQuery`.
* Corrected the sorting logic in `getTZQuery` to sort by numeric offset values rather than strings, ensuring proper ordering.

### Continuous Integration and Dependency Updates
* Updated GitHub Actions dependencies to the latest major versions in workflow files (`release.yml`, `snapshot.yml`, `tests.yml`), including `actions/upload-artifact`, `actions/download-artifact`, `stefanzweifel/git-auto-commit-action`, and `mikepenz/action-junit-report`. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L100-R100) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L183-R183) [[3]](diffhunk://#diff-4c087648fbb704b0cc106eebfff7779856a6af4a6987e919debdd3afd1fdf7bbL41-R41) [[4]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL92-R93) [[5]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL104-R105) [[6]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL117-R118)
* Added support for testing against ColdBox 8.x and BoxLang PRIME in the test matrix. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL22-R22) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL38-R41)

### Documentation
* Updated the changelog for version 3.5.0 with details on bug fixes, new features, and dependency updates.
* Fixed changelog links to correctly reference the latest releases.